### PR TITLE
fix(ci): resolve black and flake8 E203 conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E127,E501,W503,W504
+ignore = E127,E203,E501,W503,W504
 exclude = .venv,build,dist,*.egg-info

--- a/src/mvn_mcp_server/tools/java_security_scan.py
+++ b/src/mvn_mcp_server/tools/java_security_scan.py
@@ -238,7 +238,7 @@ def _apply_pagination(
         offset = max(0, total_vulnerabilities - max_results)
 
     # Apply pagination
-    scan_results = all_results[offset:offset + max_results]
+    scan_results = all_results[offset : offset + max_results]
 
     # Calculate pagination info
     has_more = (offset + max_results) < total_vulnerabilities


### PR DESCRIPTION
## Summary
Resolves the CI pipeline failure caused by a conflict between Black formatter and flake8's E203 rule.

## Changes
- Add E203 to flake8 ignore list in setup.cfg for Black compatibility  
- Apply black formatting with spaces around slice colons in java_security_scan.py
- Both black and flake8 now pass without conflicts

## Technical Details
This addresses the known incompatibility between Black and flake8's E203 rule (whitespace before ':'). Black formats slice notation as  which is PEP 8 compliant, but flake8's E203 rule flags this as an error.

The solution follows Black's official documentation recommendation to ignore E203 when using Black with flake8.

## Test plan
- [x] Black formatting check passes
- [x] flake8 linting check passes  
- [x] MyPy type checking passes
- [x] PyTest runs successfully

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)