### PR TITLE
fix(copilot): move setup file to workflows directory and update format

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,11 +1,21 @@
-name: Setup Maven MCP Server Development Environment
+name: "Copilot Setup Steps"
 
-on:
-  workflow_call:
+# Allow testing of the setup steps from your repository's "Actions" tab.
+on: workflow_dispatch
 
 jobs:
-  setup:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
     runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # Need contents: read to clone the repository and install dependencies
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Fixes the Copilot setup file location and format to comply with GitHub Copilot coding agent requirements.

## Changes
- **File Location**: Moved from `.github/copilot-setup-steps.yml` to `.github/workflows/copilot-setup-steps.yml`
- **Job Name**: Changed from `setup` to `copilot-setup-steps` (required by Copilot)
- **Trigger**: Updated from `workflow_call` to `workflow_dispatch` for manual testing capability
- **Permissions**: Added minimum required `contents: read` permission
- **Documentation**: Added comments explaining Copilot-specific requirements

## Technical Details
- The job **must** be named `copilot-setup-steps` or Copilot won't recognize it
- The file **must** be in `.github/workflows/` directory
- Using `workflow_dispatch` allows manual testing from the repository's Actions tab
- The setup installs Python 3.12, uv package manager, and all project dependencies
- Includes verification steps to ensure the environment is ready for Copilot operations

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)